### PR TITLE
Restrict FriendlyID to 4.x branch

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,7 @@ gem 'indextank'
 
 gem 'bluecloth'
 gem 'kramdown'
-gem 'friendly_id'
+gem 'friendly_id', '~> 4.0'
 gem 'gon'
 gem 'paperclip', '~> 3.0'
 gem 'aws-sdk', '~> 1.3.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -341,7 +341,7 @@ DEPENDENCIES
   facets
   factory_girl_rails
   foreman
-  friendly_id
+  friendly_id (~> 4.0)
   gon
   guard-rspec
   guard-spork


### PR DESCRIPTION
For Rails3 compatibilty it's best to use the 4.x stable branch of
FriendlyId. FriendlyId5 is only compatible with Rails4+.

https://github.com/norman/friendly_id/blob/master/README.md
