### PR TITLE
Fixes issues with simplecov + spork.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,14 +7,14 @@ gem 'pg'
 gem 'thin'
 gem 'foreman'
 
-gem 'newrelic_rpm', :group => [:production, :staging, :development]
+gem 'newrelic_rpm', group: [:production, :staging, :development]
 gem 'annotate', '~>2.4.1.beta'
 gem 'progressbar'
-gem 'facets', :require => false
+gem 'facets', require: false
 gem 'jquery-ui-rails'
 gem 'jquery-rails', '~> 2.3.0'
 
-gem 'meta-tags', :require => 'meta_tags'
+gem 'meta-tags', require: 'meta_tags'
 
 gem 'delayed_job_active_record'
 gem 'dalli'
@@ -62,6 +62,6 @@ group :test do
   gem 'guard-spork'
   gem 'capybara-webkit'
   gem 'database_cleaner'
-  gem 'simplecov', :require => false
+  gem 'simplecov', '~> 0.7.1', require: false
   gem 'webmock'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -98,7 +98,6 @@ GEM
       railties (~> 3.1)
       warden (~> 1.2.1)
     diff-lcs (1.2.5)
-    docile (1.1.3)
     dotenv (0.11.1)
       dotenv-deployment (~> 0.0.2)
     dotenv-deployment (0.0.2)
@@ -278,11 +277,10 @@ GEM
     shoulda-context (1.2.1)
     shoulda-matchers (2.6.1)
       activesupport (>= 3.0.0)
-    simplecov (0.8.2)
-      docile (~> 1.1.0)
-      multi_json
-      simplecov-html (~> 0.8.0)
-    simplecov-html (0.8.0)
+    simplecov (0.7.1)
+      multi_json (~> 1.0)
+      simplecov-html (~> 0.7.1)
+    simplecov-html (0.7.1)
     slop (3.5.0)
     spork (1.0.0rc4)
     spork-rails (4.0.0)
@@ -368,7 +366,7 @@ DEPENDENCIES
   rspec-rails (>= 2.10.1)
   sass-rails (~> 3.2.5)
   shoulda
-  simplecov
+  simplecov (~> 0.7.1)
   spork-rails
   tanker
   text

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,8 +1,14 @@
 # encoding: UTF-8
-
 require 'spork'
 
 Spork.prefork do
+
+  unless ENV['DRB']
+    require 'simplecov'
+    SimpleCov.start 'rails'
+  end
+
+
   def logger
     Rails.logger
   end
@@ -13,7 +19,6 @@ Spork.prefork do
 
   require 'database_cleaner'
   require 'rubygems'
-  require 'simplecov'
   require 'capybara/rspec'
   Capybara.javascript_driver = :webkit
 
@@ -47,5 +52,8 @@ Spork.prefork do
 end
 
 Spork.each_run do
-  SimpleCov.start 'rails'
+  if ENV['DRB']
+    require 'simplecov'
+    SimpleCov.start 'rails'
+  end
 end


### PR DESCRIPTION
I needed to make some minor changes to the spec_helper.rb file and restrict simplecov to the 0.7.x branch (there is a bug in the 0.8 branch that has yet to be fixed: https://github.com/colszowka/simplecov

I also took the liberty to update the Gemfile with Ruby19 hash syntax.
