### PR TITLE
Use a content_tag helper for category.description

### DIFF
--- a/app/views/categories/show.html.erb
+++ b/app/views/categories/show.html.erb
@@ -12,10 +12,7 @@
         <div class="header">
           <h1><%= @category.name %></h1>
         </div>
-        <% if @category.description.strip != "" %>
-          <p><% @category.description %></p>
-          <br/>
-        <% end %>
+        <%= content_tag_for :p,  @category.description unless @category.description.blank? %>
         <ul>
           <% @category.articles.by_access_count.each do |article| %>
             <% next unless article.published? %>


### PR DESCRIPTION
In category#show the app would throw a NoMethodError on categories with nil descriptions (this is from db/seeds.rb).  We may also want to add some example descriptions to the seeds.rb file.
