### PR TITLE
Integrate vcr + test markdownifier

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,12 +47,14 @@ group :assets do
 end
 
 group :test, :development do
+  gem 'spring-commands-rspec'
   gem 'memcached'
   gem 'dotenv-rails'
   gem 'rspec-rails', '>= 2.10.1'
 end
 
 group :test do
+  gem 'vcr'
   gem 'shoulda'
   gem 'capybara'
   gem 'launchy'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -286,6 +286,9 @@ GEM
     spork-rails (4.0.0)
       rails (>= 3.0.0, < 5)
       spork (>= 1.0rc0)
+    spring (1.1.3)
+    spring-commands-rspec (1.0.2)
+      spring (>= 0.9.1)
     sprockets (2.2.2)
       hike (~> 1.2)
       multi_json (~> 1.0)
@@ -312,6 +315,7 @@ GEM
       execjs (>= 0.3.0)
       json (>= 1.8.0)
     uuidtools (2.1.4)
+    vcr (2.9.0)
     warden (1.2.3)
       rack (>= 1.0)
     webmock (1.18.0)
@@ -368,9 +372,11 @@ DEPENDENCIES
   shoulda
   simplecov (~> 0.7.1)
   spork-rails
+  spring-commands-rspec
   tanker
   text
   therubyracer
   thin
   uglifier (>= 1.0.3)
+  vcr
   webmock

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,11 @@
 # encoding: UTF-8
 require 'spork'
+require 'vcr'
+
+VCR.configure do |c|
+  c.cassette_library_dir = 'fixtures/vcr_cassettes'
+  c.hook_into :webmock # or :fakeweb
+end
 
 Spork.prefork do
 


### PR DESCRIPTION
Uses the VCR gem to easily and quickly test code that uses external services, such as the `Markdownifier` class.
