### PR TITLE
Fixes #29 + #30 - issues with guide views

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,26 +50,26 @@ group :assets do
 end
 
 group :test, :development do
-  gem 'faker'
-  gem 'spring-commands-rspec'
-  gem 'memcached'
   gem 'dotenv-rails'
+  gem 'factory_girl_rails'
+  gem 'faker'
+  gem 'inch', require: false
+  gem 'memcached'
   gem 'rspec-rails', '>= 2.10.1'
   gem 'rspec-html-matchers'
-  gem 'inch', require: false
+  gem 'spring-commands-rspec'
 end
 
 group :test do
-  gem 'vcr'
-  gem 'shoulda'
   gem 'capybara'
-  gem 'launchy'
-  gem 'guard-rspec'
-  gem 'factory_girl_rails'
-  gem 'spork-rails'
-  gem 'guard-spork'
   gem 'capybara-webkit'
   gem 'database_cleaner'
+  gem 'guard-rspec'
+  gem 'guard-spork'
+  gem 'launchy'
+  gem 'shoulda'
   gem 'simplecov', '~> 0.7.1', require: false
+  gem 'spork-rails'
   gem 'webmock'
+  gem 'vcr'
 end

--- a/app/helpers/guides_helper.rb
+++ b/app/helpers/guides_helper.rb
@@ -1,0 +1,13 @@
+module GuidesHelper
+  def meta_tag_hash(article)
+  	{ description: article.preview,
+      canonical: official_government_long_url(request.fullpath),
+      title: set_meta_tags_title(article) }
+  end
+
+  private
+
+  def set_meta_tags_title(article)
+  	article.category.nil? ? [article.title] : [article.category.name, article.title]  
+  end
+end

--- a/app/views/categories/show.html.erb
+++ b/app/views/categories/show.html.erb
@@ -19,7 +19,7 @@
           <% @category.articles.by_access_count.each do |article| %>
             <% next unless article.published? %>
               <li class="article-listing">
-                <%= content_tag( :h2, link_to( article.title, article_path(article.id) ) ) %>
+                <%= content_tag( :h2, link_to( article.title, article) ) %>
                 <p class="preview"><%= article.preview %></p>
                 <div class="other-langs">
               <% if article.title_es.present? %>

--- a/app/views/guides/show.html.erb
+++ b/app/views/guides/show.html.erb
@@ -1,6 +1,4 @@
-<% set_meta_tags :description => @article.try(:preview),
-                  :canonical => official_government_long_url(request.fullpath),
-                 :title => [@article.category.try(:name), @article.title] %>
+<% set_meta_tags meta_tag_hash(@article) %>
 <div class="page-container article">
   <div class="breadcrumbs">
     <%= link_to( "Home", root_url) %>

--- a/spec/factories/categories.rb
+++ b/spec/factories/categories.rb
@@ -5,8 +5,7 @@ FactoryGirl.define do
 
     factory :category_with_articles do
       after(:build) do |category|
-        category.articles = [FactoryGirl.create(:article,
-         :category => category)]
+        category.articles << FactoryGirl.create(:article, category: category)
       end
     end
   end

--- a/spec/helpers/guides_helper_spec.rb
+++ b/spec/helpers/guides_helper_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+describe GuidesHelper do
+  describe '#meta_tag_hash' do
+    let (:article) { create(:article) }
+
+    it 'returns a hash using data from the article object' do
+      expect(helper.meta_tag_hash(article)[:description]).to eq article.preview
+      expect(helper.meta_tag_hash(article)[:canonical]).to eq 'http://example.gov'
+    end
+
+    context 'when the article belongs to a category' do
+      let (:article) { create(:article) }
+      let (:category) { create(:category) }
+
+      it 'the hash :title key returns an array with the category and title' do
+        article.category = category
+        expect(helper.meta_tag_hash(article)[:title]).to eq [article.category.name, article.title]
+      end
+    end
+
+    context 'when the article does not belongs to a category' do
+      let (:article) { create(:article) }
+      let (:category) { create(:category) }
+ 
+      it 'the hash :title key returns an array with only the title' do
+        expect(helper.meta_tag_hash(article)[:title]).to eq [article.title]
+      end
+    end
+
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,6 +26,7 @@ Spork.prefork do
 
   RSpec.configure do |config|
     config.include Capybara::DSL
+    config.include FactoryGirl::Syntax::Methods
 
     config.before(:suite) do
       DatabaseCleaner.strategy = :transaction


### PR DESCRIPTION
Guides were not displaying because of a missing ‘,’ in the meta tag information in the guides view.

Also fixed and issue where the categories were not linking to the correct article urls.

@nickbristow can you double check this to make sure I got all that's needed for this commit?
