### PR TITLE
Remove deprecated and unused test code

### DIFF
--- a/Guardfile
+++ b/Guardfile
@@ -1,12 +1,9 @@
-# A sample Guardfile
-# More info at https://github.com/guard/guard#readme
-
-guard 'rspec', :version => 2, :cli => "--fail-fast" do
+guard 'rspec' do
   watch(%r{^spec/.+_spec\.rb$})
   watch(%r{^lib/(.+)\.rb$})     { |m| "spec/lib/#{m[1]}_spec.rb" }
   watch('spec/spec_helper.rb')  { "spec" }
 
-  # Rails example
+  # Rails
   watch(%r{^app/(.+)\.rb$})                           { |m| "spec/#{m[1]}_spec.rb" }
   watch(%r{^app/(.*)(\.erb|\.haml)$})                 { |m| "spec/#{m[1]}#{m[2]}_spec.rb" }
   watch(%r{^app/controllers/(.+)_(controller)\.rb$})  { |m| ["spec/routing/#{m[1]}_routing_spec.rb", "spec/#{m[2]}s/#{m[1]}_#{m[2]}_spec.rb", "spec/acceptance/#{m[1]}_spec.rb"] }
@@ -14,12 +11,11 @@ guard 'rspec', :version => 2, :cli => "--fail-fast" do
   watch('config/routes.rb')                           { "spec/routing" }
   watch('app/controllers/application_controller.rb')  { "spec/controllers" }
   
-  # Capybara request specs
+  # Capybara
   watch(%r{^app/views/(.+)/.*\.(erb|haml)$})          { |m| "spec/requests/#{m[1]}_spec.rb" }
 end
 
-
-guard 'spork', :cucumber_env => { 'RAILS_ENV' => 'test' }, :rspec_env => { 'RAILS_ENV' => 'test' } do
+guard 'spork', cucumber_env: { 'RAILS_ENV' => 'test' }, rspec_env: { 'RAILS_ENV' => 'test' } do
   watch('config/application.rb')
   watch('config/environment.rb')
   watch('config/environments/test.rb')

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,39 +1,24 @@
-# encoding: UTF-8
+ENV["RAILS_ENV"] ||= 'test'
 require 'spork'
 
 Spork.prefork do
-
   unless ENV['DRB']
     require 'simplecov'
     SimpleCov.start 'rails'
   end
 
-
-  def logger
-    Rails.logger
-  end
-
-  def saop
-    save_and_open_page
-  end
-
-  require 'database_cleaner'
-  require 'rubygems'
   require 'capybara/rspec'
-  Capybara.javascript_driver = :webkit
-
-  ENV["RAILS_ENV"] ||= 'test'
+  require 'database_cleaner'
   require File.expand_path("../../config/environment", __FILE__)
   require 'rspec/rails'
   require 'rspec/autorun'
+  require 'webmock/rspec'
   Dir[Rails.root.join("spec/support/**/*.rb")].each {|f| require f}
 
-  require 'webmock/rspec'
+  Capybara.javascript_driver = :webkit
   WebMock.disable_net_connect!(allow_localhost: true)
 
   RSpec.configure do |config|
-    config.fixture_path = "#{::Rails.root}/spec/fixtures"
-    config.infer_base_class_for_anonymous_controllers = false
     config.include Capybara::DSL
 
     config.before(:suite) do


### PR DESCRIPTION
There were two depcrecated statements in the Guardfile (:cli and :version).  I also removed some code that is not used in the spec_helper.
