### PR TITLE
Fix i18n deprecation warning

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -34,6 +34,9 @@ module Oaklandanswers
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
     # config.i18n.default_locale = :de
+    config.i18n.enforce_available_locales = true
+    # or if one of your gem compete for pre-loading, use
+    I18n.config.enforce_available_locales = true
 
     # Configure the default encoding used in templates for Ruby 1.9.
     config.encoding = "utf-8"


### PR DESCRIPTION
This fixes the depcrecation warning by setting the enforce_available_locales value.  See http://stackoverflow.com/questions/20361428/rails-i18n-validation-deprecation-warning.
