### PR TITLE
Fixes deprecation warnings with formtastic

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,7 @@ gem 'memcachier'
 gem 'dalli'
 gem 'kgio'
 
-gem 'activeadmin', '0.4.4'
+gem 'activeadmin', '~> 0.5.1'
 gem 'devise', '~> 2.0'
 gem 'cancan'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,11 +14,12 @@ GEM
       rack-cache (~> 1.2)
       rack-test (~> 0.6.1)
       sprockets (~> 2.2.1)
-    activeadmin (0.4.4)
+    activeadmin (0.5.1)
+      arbre (>= 1.0.1)
       bourbon (>= 1.0.0)
       devise (>= 1.1.2)
       fastercsv
-      formtastic (~> 2.1.1)
+      formtastic (>= 2.0.0)
       inherited_resources (>= 1.3.1)
       jquery-rails (>= 1.0.0)
       kaminari (>= 0.13.0)
@@ -41,6 +42,8 @@ GEM
       multi_json (~> 1.0)
     addressable (2.3.6)
     annotate (2.4.1.beta1)
+    arbre (1.0.1)
+      activesupport (>= 3.0.0)
     arel (3.0.3)
     aws-sdk (1.3.9)
       httparty (~> 0.7)
@@ -122,8 +125,8 @@ GEM
       dotenv (>= 0.7)
       thor (>= 0.13.6)
     formatador (0.2.5)
-    formtastic (2.1.1)
-      actionpack (~> 3.0)
+    formtastic (2.2.1)
+      actionpack (>= 3.0)
     friendly_id (4.0.10.1)
       activerecord (>= 3.0, < 4.0)
     gon (5.0.4)
@@ -328,7 +331,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  activeadmin (= 0.4.4)
+  activeadmin (~> 0.5.1)
   annotate (~> 2.4.1.beta)
   aws-sdk (~> 1.3.4)
   bluecloth

--- a/app/admin/articles.rb
+++ b/app/admin/articles.rb
@@ -42,6 +42,6 @@ ActiveAdmin.register Article do
       f.input :author_pic
       f.input :author_name
     end
-    f.buttons
+    f.actions
   end
 end

--- a/app/admin/categories.rb
+++ b/app/admin/categories.rb
@@ -14,7 +14,7 @@ ActiveAdmin.register Category do
       f.input :name
       f.input :description
     end
-    f.buttons
+    f.actions
   end
 
   show do

--- a/app/admin/contacts.rb
+++ b/app/admin/contacts.rb
@@ -18,7 +18,7 @@ ActiveAdmin.register Contact do
       f.input :department
       f.input :description
     end
-    f.buttons
+    f.actions
   end
 
   # FIXME: not working

--- a/app/admin/quick_answers.rb
+++ b/app/admin/quick_answers.rb
@@ -68,6 +68,6 @@ ActiveAdmin.register QuickAnswer do
       f.input :content_main_extra, label: "Full Content"
       f.input :content_need_to_know, label: "Related Resources"
     end
-    f.buttons
+    f.actions
   end
 end

--- a/app/admin/users.rb
+++ b/app/admin/users.rb
@@ -25,7 +25,7 @@ ActiveAdmin.register User do
       f.input :is_editor,  :label => "Editor"
       f.input :is_writer,  :label => "Writer"
     end
-    f.buttons
+    f.actions
   end
 
   show do |user|

--- a/app/views/admin/guide_steps/_form.html.erb
+++ b/app/views/admin/guide_steps/_form.html.erb
@@ -15,5 +15,5 @@
     <div class="clear"></div>
 
   <%end%>
-  <%=f.buttons :commit %>
+  <%=f.actions :submit %>
 <% end %>


### PR DESCRIPTION
This fixes the depcrecation warnings with formtastic. I also updated ActiveAdmin to v0.5.1. We will still need to remove ActiveAdmin::Dashboard which is also deprecated as of v0.6.0 (see #11 & #12).
