### PR TITLE
html to markdown occurs locally (clean)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,7 @@ gem 'indextank'
 
 gem 'bluecloth'
 gem 'kramdown'
+gem 'reverse_markdown'
 gem 'friendly_id', '~> 4.0'
 gem 'gon'
 gem 'paperclip', '~> 3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -127,8 +127,8 @@ GEM
       dotenv (>= 0.7)
       thor (>= 0.13.6)
     formatador (0.2.5)
-    formtastic (2.2.1)
-      actionpack (>= 3.0)
+    formtastic (2.1.1)
+      actionpack (~> 3.0)
     friendly_id (4.0.10.1)
       activerecord (>= 3.0, < 4.0)
     gon (5.0.4)
@@ -253,6 +253,8 @@ GEM
     ref (1.0.5)
     responders (1.0.0)
       railties (>= 3.2, < 5)
+    reverse_markdown (0.5.1)
+      nokogiri
     rspec (2.14.1)
       rspec-core (~> 2.14.0)
       rspec-expectations (~> 2.14.0)
@@ -378,6 +380,7 @@ DEPENDENCIES
   progressbar
   rails (= 3.2.17)
   rspec-html-matchers
+  reverse_markdown
   rspec-rails (>= 2.10.1)
   sass-rails (~> 3.2.5)
   shoulda

--- a/lib/markdownifier.rb
+++ b/lib/markdownifier.rb
@@ -1,11 +1,11 @@
+require 'reverse_markdown'
+
 module Markdownifier
   class Markdownifier
-    include HTTParty
 
     def html_to_markdown( html, options = {} )
-      options.merge!( { :query => { :html => html } } )
-      response = self.class.post( 'http://fuckyeahmarkdown.com/go/', options )
-      return response.body
+      ReverseMarkdown.convert(html)
     end
+
   end
 end

--- a/spec/lib/markdownifier_spec.rb
+++ b/spec/lib/markdownifier_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+describe Markdownifier do
+  it "converts markdown to html" do
+    markdownifier = Markdownifier::Markdownifier.new
+    input = "<h1>hello</h1>"
+    output = markdownifier.html_to_markdown(input)
+    output.class.should == String
+    output[0].should == "#"
+  end
+end


### PR DESCRIPTION
Improves security and privacy by converting html to markdown locally (instead of via an untrusted API).
- Use this PR instead of https://github.com/codeforamerica/oakland_answers/pull/16 (used `cherry-pick` to remove commits that were not germane to this feature)
- Currently requesting to pull against `dev` branch. is this ok? or should it be master?
- Includes a simple spec
