### PR TITLE
added spring for rspec (clean)

### DIFF
--- a/Guardfile
+++ b/Guardfile
@@ -1,4 +1,4 @@
-guard 'rspec' do
+guard 'rspec', cmd: 'spring rspec' do
   watch(%r{^spec/.+_spec\.rb$})
   watch(%r{^lib/(.+)\.rb$})     { |m| "spec/lib/#{m[1]}_spec.rb" }
   watch('spec/spec_helper.rb')  { "spec" }

--- a/bin/rspec
+++ b/bin/rspec
@@ -1,0 +1,7 @@
+#!/usr/bin/env ruby
+begin
+  load File.expand_path("../spring", __FILE__)
+rescue LoadError
+end
+require 'bundler/setup'
+load Gem.bin_path('rspec-core', 'rspec')

--- a/bin/spring
+++ b/bin/spring
@@ -1,0 +1,18 @@
+#!/usr/bin/env ruby
+
+# This file loads spring without using Bundler, in order to be fast
+# It gets overwritten when you run the `spring binstub` command
+
+unless defined?(Spring)
+  require "rubygems"
+  require "bundler"
+
+  if match = Bundler.default_lockfile.read.match(/^GEM$.*?^    spring \((.*?)\)$.*?^$/m)
+    ENV["GEM_PATH"] = ([Bundler.bundle_path.to_s] + Gem.path).join(File::PATH_SEPARATOR)
+    ENV["GEM_HOME"] = ""
+    Gem.paths = ENV
+
+    gem "spring", match[1]
+    require "spring/binstub"
+  end
+end


### PR DESCRIPTION
Should speed up the test suite. With the addition of spring, specs take ~14 seconds to run. Use instead of https://github.com/codeforamerica/oakland_answers/pull/10
