### PR TITLE
Recreate Gemfile.lock in correct order

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -391,9 +391,9 @@ DEPENDENCIES
   paperclip (~> 3.0)
   pg
   progressbar
-  rspec-html-matchers
   rails (> 3.2.17)
   reverse_markdown
+  rspec-html-matchers
   rspec-rails (>= 2.10.1)
   sass-rails (~> 3.2.5)
   shoulda


### PR DESCRIPTION
I believe the list of gems in the Gemfile.lock was rearranged with a merge.  A rebundle fixed the order.
