### PR TITLE
Added skip nav link and styles

### DIFF
--- a/app/assets/stylesheets/all/style.css
+++ b/app/assets/stylesheets/all/style.css
@@ -896,3 +896,21 @@ ul.about-list li {
   padding-right:4px;
   float:left;
 }
+
+#skip_nav {
+  font-size: 80%;
+  font-family: inherit;
+
+}
+
+#skip_nav a {
+  color: #000000;
+  position: absolute;
+  margin-left: -9000px;
+}
+#skip_nav a:focus, #skipLinks a:active {
+  display: block;
+  width: 7.5em;
+  margin-left: 50px;
+}
+

--- a/app/assets/stylesheets/mobile/mobile.css
+++ b/app/assets/stylesheets/mobile/mobile.css
@@ -142,3 +142,8 @@ div.article h1{
 #cfa_corner_ribbon {
   display:none;
 }
+#skip_nav a:focus, #skipLinks a:active {
+  display: block;
+  width: 7.5em;
+  margin-left: 20px;
+}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -25,6 +25,9 @@
 </head>
 <body class="<%= @bodyclass %>" onload="if($){ $('#query').focus(); }">
 <div id="wrapper">
+  <div id="skip_nav">
+    <a href="#main_content_container">Skip Navigation</a>
+  </div>
   <div class="navbar-top">
     <!-- <p class="notice alert alert-info"><%= notice %></p>
     <p class="alert alert-error"><%= alert %></p> -->
@@ -53,7 +56,7 @@
       </div><!-- /row -->
     </div>
   </div><!-- /navbar-top -->
-  <div class="container main clearfix"><!-- main content container -->
+  <div class="container main clearfix" id="main_content_container"><!-- main content container -->
 
 
 


### PR DESCRIPTION
Skip navigation is required for the site be considered 508 compliant. I've added a basic div with id skip_nav to the top of the wrapper element. 

Using CSS, the link is hidden from view until the element is tabbed to. 

The link is just an anchor link which points to the container of the yield which i've added an id to (main_content_container)
